### PR TITLE
chore: Improve pip button iOS

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -659,7 +659,11 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
         [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
         AVPlayerLayer *playerLayer = self._betterPlayerView.playerLayer;
         if (!_pipController && playerLayer && [AVPictureInPictureController isPictureInPictureSupported]) {
-            _pipController = [[AVPictureInPictureController alloc] initWithPlayerLayer: playerLayer];
+            if (playerLayer != _originPlayerView.playerLayer && _originPlayerView.playerLayer != nil) {
+                _pipController = [[AVPictureInPictureController alloc] initWithPlayerLayer: _originPlayerView.playerLayer];
+            } else {
+                _pipController = [[AVPictureInPictureController alloc] initWithPlayerLayer: playerLayer];
+            }
             if (@available(iOS 14.2, *)) {
                 _pipController.canStartPictureInPictureAutomaticallyFromInline = self._willStartPictureInPicture;
             }


### PR DESCRIPTION
Currently, playerLayer always bounds to the latest PlayerView.
So, when the latest PlayerView is disposed, the origin PlayerView's playerLayer is not used for PIP.